### PR TITLE
Implement Stringer in constraint

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -47,6 +47,15 @@ func MustConstraint(cs string) Constraints {
 	return c
 }
 
+// String returns the constraint as a string.
+func (cs Constraints) String() string {
+	s := make([]string, len(cs))
+	for i, c := range cs {
+		s[i] = c.String()
+	}
+	return strings.Join(s, ", ")
+}
+
 // Check returns true if the given version satisfies all of the constraints.
 func (cs Constraints) Check(v *Version) bool {
 	for _, c := range cs {

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -151,3 +151,11 @@ func TestCheckString(t *testing.T) {
 	assert.False(t, c.CheckString("0.9.9"))
 	assert.False(t, c.CheckString("x"))
 }
+
+func TestString(t *testing.T) {
+	c, err := NewConstraint(">= 1.0.0, < 2.0.0")
+	assert.NoError(t, err)
+
+	assert.Equal(t, ">= 1.0.0, < 2.0.0", c.String())
+}
+


### PR DESCRIPTION
The version.Constraints did not implement the Stringer interface, which made printing it out difficult.

