### PR TITLE
Add v.Base(), v.Clone() and v.WithK0s(int)

### DIFF
--- a/version.go
+++ b/version.go
@@ -135,7 +135,7 @@ func (v *Version) IsK0s() bool {
 	return v.isK0s
 }
 
-// K0s returns the k0s version (eg 4 from v1.2.3-k0s.4)
+// K0s returns the k0s version (eg 4 from v1.2.3-k0s.4) and true if the version is a k0s version. Otherwise it returns -1 and false.
 func (v *Version) K0s() (int, bool) {
 	if !v.isK0s {
 		return -1, false

--- a/version.go
+++ b/version.go
@@ -137,7 +137,28 @@ func (v *Version) IsK0s() bool {
 
 // K0sVersion returns the k0s version (eg 4 from v1.2.3-k0s.4)
 func (v *Version) K0sVersion() int {
+	if !v.isK0s {
+		return -1
+	}
 	return v.k0s
+}
+
+// Base returns the version as a string without the k0s or metadata part (eg v1.2.3+k0s.4 -> v1.2.3)
+func (v *Version) Base() string {
+	return strings.SplitN(v.String(), "+", 2)[0]
+}
+
+// Clone returns a copy of the k0s version
+func (v *Version) Clone() *Version {
+	return &Version{comparableFields: v.comparableFields}
+}
+
+// WithK0s returns a copy of the k0s version with the k0s part set to the supplied value
+func (v *Version) WithK0s(n int) *Version {
+	newV := v.Clone()
+	newV.isK0s = true
+	newV.k0s = n
+	return newV
 }
 
 // Metadata returns the metadata part of the k0s version (eg 123abc from v1.2.3+k0s.1.123abc)

--- a/version.go
+++ b/version.go
@@ -135,12 +135,12 @@ func (v *Version) IsK0s() bool {
 	return v.isK0s
 }
 
-// K0sVersion returns the k0s version (eg 4 from v1.2.3-k0s.4)
-func (v *Version) K0sVersion() int {
+// K0s returns the k0s version (eg 4 from v1.2.3-k0s.4)
+func (v *Version) K0s() (int, bool) {
 	if !v.isK0s {
-		return -1
+		return -1, false
 	}
-	return v.k0s
+	return v.k0s, true
 }
 
 // Base returns the version as a string without the k0s or metadata part (eg v1.2.3+k0s.4 -> v1.2.3)

--- a/version.go
+++ b/version.go
@@ -135,12 +135,9 @@ func (v *Version) IsK0s() bool {
 	return v.isK0s
 }
 
-// K0s returns the k0s version (eg 4 from v1.2.3-k0s.4) and true if the version is a k0s version. Otherwise it returns -1 and false.
+// K0s returns the k0s version (eg 4 from v1.2.3-k0s.4) and true if the version is a k0s version. Otherwise it returns 0 and false.
 func (v *Version) K0s() (int, bool) {
-	if !v.isK0s {
-		return -1, false
-	}
-	return v.k0s, true
+	return v.k0s, v.isK0s
 }
 
 // Base returns the version as a string without the k0s or metadata part (eg v1.2.3+k0s.4 -> v1.2.3)

--- a/version_test.go
+++ b/version_test.go
@@ -53,8 +53,31 @@ func TestNewVersion(t *testing.T) {
 	v, err := version.NewVersion("1.23.3+k0s.1")
 	NoError(t, err)
 	Equal(t, "v1.23.3+k0s.1", v.String())
+	Equal(t, "v1.23.3", v.Base())
 	_, err = version.NewVersion("v1.23.b+k0s.1")
 	Error(t, err)
+}
+
+func TestWithK0s(t *testing.T) {
+	v, err := version.NewVersion("1.23.3+k0s.1")
+	NoError(t, err)
+	True(t, v.IsK0s())
+	Equal(t, 1, v.K0sVersion())
+	v2 := v.WithK0s(2)
+	NoError(t, err)
+	Equal(t, "v1.23.3+k0s.2", v2.String())
+	Equal(t, 2, v2.K0sVersion())
+	// ensure original didnt change
+	Equal(t, 1, v.K0sVersion())
+
+	v, err = version.NewVersion("1.23.3")
+	NoError(t, err)
+	False(t, v.IsK0s())
+	v2 = v.WithK0s(2)
+	NoError(t, err)
+	Equal(t, "v1.23.3+k0s.2", v2.String())
+	// ensure original didnt change
+	Equal(t, -1, v.K0sVersion())
 }
 
 func TestBasicComparison(t *testing.T) {

--- a/version_test.go
+++ b/version_test.go
@@ -10,18 +10,21 @@ import (
 )
 
 func NoError(t *testing.T, err error) {
+	t.Helper() // these make the log messages display the correct line number
 	if err != nil {
 		t.Fatalf("Received an unexpected error: %v", err)
 	}
 }
 
 func Error(t *testing.T, err error) {
+	t.Helper()
 	if err == nil {
 		t.Fatalf("Expected an error, got nil")
 	}
 }
 
 func Equal(t *testing.T, expected, actual interface{}) {
+	t.Helper()
 	if reflect.DeepEqual(expected, actual) {
 		return
 	}
@@ -29,6 +32,7 @@ func Equal(t *testing.T, expected, actual interface{}) {
 }
 
 func True(t *testing.T, actual bool) {
+	t.Helper()
 	if actual {
 		return
 	}
@@ -36,6 +40,7 @@ func True(t *testing.T, actual bool) {
 }
 
 func False(t *testing.T, actual bool) {
+	t.Helper()
 	if !actual {
 		return
 	}
@@ -43,6 +48,7 @@ func False(t *testing.T, actual bool) {
 }
 
 func Nil(t *testing.T, actual interface{}) {
+	t.Helper()
 	if actual == nil {
 		return
 	}
@@ -62,13 +68,19 @@ func TestWithK0s(t *testing.T) {
 	v, err := version.NewVersion("1.23.3+k0s.1")
 	NoError(t, err)
 	True(t, v.IsK0s())
-	Equal(t, 1, v.K0sVersion())
+	k0s, ok := v.K0s()
+	Equal(t, 1, k0s)
+	True(t, ok)
 	v2 := v.WithK0s(2)
 	NoError(t, err)
 	Equal(t, "v1.23.3+k0s.2", v2.String())
-	Equal(t, 2, v2.K0sVersion())
+	k0s, ok = v2.K0s()
+	Equal(t, 2, k0s)
+	True(t, ok)
 	// ensure original didnt change
-	Equal(t, 1, v.K0sVersion())
+	k0s, ok = v.K0s()
+	True(t, ok)
+	Equal(t, 1, k0s)
 
 	v, err = version.NewVersion("1.23.3")
 	NoError(t, err)
@@ -77,7 +89,9 @@ func TestWithK0s(t *testing.T) {
 	NoError(t, err)
 	Equal(t, "v1.23.3+k0s.2", v2.String())
 	// ensure original didnt change
-	Equal(t, -1, v.K0sVersion())
+	False(t, v.IsK0s())
+	_, ok = v.K0s()
+	False(t, ok)
 }
 
 func TestBasicComparison(t *testing.T) {


### PR DESCRIPTION
- `v.K0s()` (ex. `v.K0sVersion()`) now returns `(v int, ok bool)`
- `v.Base()` returns a string without the meta part (`v1.23.4+k0s.5` => `"v1.23.4"`).
- `v.Clone()` returns a copy
- `v.WithK0s(n int)` returns a copy with +k0s.n
- Also changed `v.K0sVersion()` to return -1 instead of 0 when `v.IsK0s()` is false.

This could be useful for example in [k0smotron](https://github.com/k0sproject/k0smotron/blob/984b08f140d4717a670f49ded7b145d756ffb936/internal/controller/controlplane/k0s_controlplane_controller.go#L84-L86)
