### PR TITLE
Add MajorMinor to match whole releases

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -80,6 +80,11 @@ func (cs Constraints) CheckString(v string) bool {
 	return cs.Check(vv)
 }
 
+// Implements [VersionMatcher]: Same as [Constraints.Check].
+func (cs Constraints) MatchesVersion(v *Version) bool {
+	return cs.Check(v)
+}
+
 // String returns the original constraint string.
 func (c *constraint) String() string {
 	return c.original
@@ -154,4 +159,3 @@ func gte(a, b *Version) bool { return b.GreaterThanOrEqual(a) }
 func lte(a, b *Version) bool { return b.LessThanOrEqual(a) }
 func eq(a, b *Version) bool  { return b.Equal(a) }
 func neq(a, b *Version) bool { return !b.Equal(a) }
-

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/k0sproject/version
 
-go 1.17
+go 1.21

--- a/majorminor.go
+++ b/majorminor.go
@@ -1,0 +1,59 @@
+package version
+
+import (
+	"cmp"
+	"fmt"
+)
+
+// MajorMinor represents the major and minor segments of a [Version].
+//
+// Useful for matching and comparing whole releases:
+//
+//	// RBAC is enabled by default since Kubernetes 1.6
+//	var rbacEnabledByDefault = version.AtLeast(version.NewMajorMinor(1, 6))
+//
+//	k0sVersion := version.MustParse(...)
+//	if k0sVersion.Is(rbacEnabledByDefault) {
+//		... do something related to RBAC
+//	}
+type MajorMinor struct {
+	major, minor uint
+}
+
+func NewMajorMinor(major, minor uint) MajorMinor {
+	return MajorMinor{major, minor}
+}
+
+// Extracts the major and minor version segments of v.
+// Non-existing segments in v are assumed to be zero.
+func (v *Version) ToMajorMinor() MajorMinor {
+	return NewMajorMinor(uint(v.segments[0]), uint(v.segments[1]))
+}
+
+// Returns the string representation of m.
+// For example, the following will return "1.2":
+//
+//	NewMajorMinor(1, 2).String()
+func (m MajorMinor) String() string {
+	return fmt.Sprintf("%d.%d", m.major, m.minor)
+}
+
+// Implements [VersionMatcher]: v matches when its major and minor version
+// segments are equal to m's major and minor segments.
+func (m MajorMinor) MatchVersion(v *Version) bool {
+	return m == v.ToMajorMinor()
+}
+
+// Compares m to other, first the major segment, then the minor segment.
+func (m MajorMinor) Compare(other MajorMinor) int {
+	if cmp := cmp.Compare(m.major, other.major); cmp != 0 {
+		return cmp
+	}
+	return cmp.Compare(m.minor, other.minor)
+}
+
+// Implements [VersionComparer]: Compares m to v by only considering v's major
+// and minor version segments. Non-existing segments in v are assumed to be zero.
+func (m MajorMinor) CompareVersion(v *Version) int {
+	return m.Compare(v.ToMajorMinor())
+}

--- a/majorminor_test.go
+++ b/majorminor_test.go
@@ -1,0 +1,79 @@
+package version_test
+
+import (
+	"testing"
+
+	"github.com/k0sproject/version"
+)
+
+func TestMajorMinorString(t *testing.T) {
+	mm := version.NewMajorMinor(1, 2)
+	if expected, actual := "1.2", mm.String(); expected != actual {
+		t.Errorf("Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestMajorMinor_FromVersion(t *testing.T) {
+	v := version.MustParse("v1.23.12-rc.1+k0s.0")
+	expected := version.NewMajorMinor(1, 23)
+	actual := v.ToMajorMinor()
+
+	if expected != actual {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}
+
+func TestMajorMinor_MatchVersion(t *testing.T) {
+	underTest := version.NewMajorMinor(1, 2)
+
+	for _, test := range []struct {
+		version  string
+		expected bool
+	}{
+		{"v0.9.1", false},
+		{"v1.1.2", false},
+		{"v1.2.3", true},
+		{"v1.3.4", false},
+		{"v2.0.5", false},
+	} {
+		v := version.MustParse(test.version)
+		if actual := underTest.MatchVersion(v); test.expected != actual {
+			t.Errorf("Expected (%s).MatchVersion(%q) to be %t, but was %t", underTest, test.version, test.expected, actual)
+		}
+		if actual := v.Is(underTest); test.expected != actual {
+			t.Errorf("Expected %q.Is(%s) to be %t, but was %t", test.version, underTest, test.expected, actual)
+		}
+	}
+}
+
+func TestMajorMinor_Compare(t *testing.T) {
+	v12 := version.NewMajorMinor(1, 2)
+	v13 := version.NewMajorMinor(1, 3)
+	v20 := version.NewMajorMinor(2, 0)
+
+	if actual := v12.Compare(v13); actual != -1 {
+		t.Errorf("Expected v12 < v13, got %d", actual)
+	}
+	if actual := v20.Compare(v12); actual != 1 {
+		t.Errorf("Expected v20 > v12, got %d", actual)
+	}
+	if actual := v12.Compare(v12); actual != 0 {
+		t.Errorf("Expected v12 == v12, got %d", actual)
+	}
+}
+
+func TestMajorMinor_CompareVersion(t *testing.T) {
+	v12 := version.NewMajorMinor(1, 2)
+	v13 := version.MustParse("1.3.4")
+	v09 := version.MustParse("0.9.8")
+
+	if actual := v12.CompareVersion(v13); actual != -1 {
+		t.Errorf("Expected v1 < v2, got %d", actual)
+	}
+	if actual := v12.CompareVersion(v09); actual != 1 {
+		t.Errorf("Expected v1 > v3, got %d", actual)
+	}
+	if actual := v12.CompareVersion(version.MustParse("1.2.2")); actual != 0 {
+		t.Errorf("Expected v1 == v1, got %d", actual)
+	}
+}


### PR DESCRIPTION
Also introduce the `VersionMatcher` and `VersionComparer` interfaces, so that new (or custom) types can be used to match and compare versions in a canonical style.

This allows, for example, this:


```go
// RBAC is enabled by default since Kubernetes 1.6
var rbacEnabledByDefault = version.AtLeast(version.NewMajorMinor(1, 6))

k0sVersion := version.MustParse(...)
if k0sVersion.Is(rbacEnabledByDefault) {
    ... do something related to RBAC
}
```