### PR TITLE
Add pre-release inclusive << and >> constraint operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,52 @@ Outputs:
 constraint > 1.2.3 satisfied by v1.23.3+k0s.1: true
 ```
 
+#### Operators
+
+Single `<` and `>` do not match prereleases unless the constraint itself is also a prerelease. Use `<<` and `>>` to allow prereleases to satisfy a stable constraint.
+
+| OP  | Description                                    |
+| --- | ---------------------------------------------- |
+| <   | Less than                                      |
+| <<  | Less than, allowing prereleases                |
+| <=  | Less than or equal to                          |
+| <== | Less than or equal to, allowing prereleases    |
+| >   | Greater than                                   |
+| >>  | Greater than, allowing prereleases             |
+| >=  | Greater than or equal to                       |
+| >== | Greater than or equal to, allowing prereleases |
+| ==  | Equal to                                       |
+| !=  | Not equal to                                   |
+
+Examples:
+
+- `< 1.0.0` 
+  - Matches `0.9.9`.
+  - Does not match `1.0.0`.
+  - Does not match `0.9.9-rc.2` or `1.0.0-alpha.1` because the constraint is stable.
+- `< 1.0.0-rc.1`
+  - Matches `0.9.9` and `1.0.0-alpha.1` because the constraint defines a pre-release.
+  - Does not match `1.0.0` or `1.0.0-rc.2`.
+- `<< 1.0.0`
+  - Matches `0.9.9`.
+  - Matches `1.0.0-alpha.1` because the pre-release inclusive `<<` operator was used.
+  - Does not match `1.0.0`.
+
+Constraints can be combined using a comma (`,`) to form multiple ranges. All ranges must be satisfied for a version to match the constraint. This allows precise control over acceptable version ranges.
+
+- `>= 1.0.0, < 2.0.0`:
+  - Matches versions from `1.0.0` (inclusive) up to `2.0.0` (exclusive).
+  - Does not match any prereleases.
+
+- `>>= 1.0.0, << 2.0.0`:
+  - Matches versions from `1.0.0` (inclusive) up to `2.0.0` (exclusive), including pre-releases of `2.0.0`.
+  - Matches `2.0.0-rc.1` but not `2.0.0`.
+  - Matches `1.0.1-alpha.1` but not `1.0.0-rc.1`.
+- `>> 1.0.0, < 2.0.0`
+  - Matches `1.1.0`.
+  - Does not match `1.1.0-rc.1` because the second part will not match any pre-releases, any pre-releases matched by the first part get rejected.
+
+
 ### Sorting
 
 ```go

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -108,35 +108,9 @@ func TestCheck(t *testing.T) {
 				false: {"0.9.9"},
 			},
 		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.constraint, func(t *testing.T) {
-			c, err := version.NewConstraint(tc.constraint)
-			NoError(t, err)
-
-			for expected, versions := range tc.truthTable {
-				t.Run(fmt.Sprintf("%t", expected), func(t *testing.T) {
-					for _, v := range versions {
-						t.Run(v, func(t *testing.T) {
-							Equal(t, expected, c.Check(version.MustParse(v)))
-						})
-					}
-				})
-			}
-		})
-	}
-}
-
-func TestCheckPre(t *testing.T) {
-	type testCase struct {
-		constraint string
-		truthTable map[bool][]string
-	}
-
-	testCases := []testCase{
+		// loose pre (1.0.1-alpha.1 satisfies >>= 1.0.0 )
 		{
-			constraint: ">= 1.0.0",
+			constraint: ">>= 1.0.0",
 			truthTable: map[bool][]string{
 				true: {
 					"1.0.0",
@@ -151,7 +125,7 @@ func TestCheckPre(t *testing.T) {
 			},
 		},
 		{
-			constraint: ">= 1.0.0-alpha.2",
+			constraint: ">>= 1.0.0-alpha.2",
 			truthTable: map[bool][]string{
 				true: {
 					"1.0.0-alpha.2",
@@ -168,7 +142,7 @@ func TestCheckPre(t *testing.T) {
 			},
 		},
 		{
-			constraint: "< 1.0.0-rc.1",
+			constraint: "<< 1.0.0-rc.1",
 			truthTable: map[bool][]string{
 				true: {
 					"1.0.0-alpha.1",
@@ -177,6 +151,20 @@ func TestCheckPre(t *testing.T) {
 				},
 				false: {
 					"1.0.0-rc.1",
+					"1.0.1-alpha.1",
+					"1.0.0",
+				},
+			},
+		},
+		{
+			constraint: "<<= 1.0.0-rc.1",
+			truthTable: map[bool][]string{
+				true: {
+					"1.0.0-rc.1",
+					"1.0.0-beta.6",
+					"0.9.9",
+				},
+				false: {
 					"1.0.1-alpha.1",
 					"1.0.0",
 				},
@@ -193,7 +181,7 @@ func TestCheckPre(t *testing.T) {
 				t.Run(fmt.Sprintf("%t", expected), func(t *testing.T) {
 					for _, v := range versions {
 						t.Run(v, func(t *testing.T) {
-							Equal(t, expected, c.CheckPre(version.MustParse(v)))
+							Equal(t, expected, c.Check(version.MustParse(v)))
 						})
 					}
 				})


### PR DESCRIPTION
Closes #24 (alternative)

In my opinion, a better option than #24.

Expands the constraint syntax to include `<<` and `>>` for creating pre-release inclusive constraints from stable ranges:

- `>> 1.0.0` will match `1.0.1-rc.1`
- `<< 2.0.0` will match `1.99.9-rc.6` but not `2.0.0`
- `>>=` and `<<=` are the "or equal" alteratives.

The single `<` and `>` versions remain unchanged (this is how it works in npm, cargo, pip, rubygems and others):

- `> 1.0.0` will match `1.0.1` but not `1.0.1-alpha.1` because the range is stable.
- `> 1.0.0-alpha.2` will match `1.0.0` and `1.99.99-beta.1` because the range itself defines a pre-release. It does not match `1.0.0-alpha.1` because it's considered lower than `alpha.2`.

I think some libraries (perhaps the semver/v3?) use an exclamation mark, something like `>! 1.0.0` but it's too confusing because it looks like a negation to me.

Also considered `~>` but decided to keep `~` and `^` reserved for how they are used in other version constraint systems.

This is to address https://github.com/k0sproject/k0sctl/pull/827

