### PR TITLE
Rename Constraints to Constraint and make it a struct instead of a slice

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -7,39 +7,37 @@ import (
 	"strings"
 )
 
-var constraintRegex = regexp.MustCompile(`^(?:(>=|>|<=|<|!=|==?)\s*)?(.+)$`)
+var constraintRegex = regexp.MustCompile(`^\s*(?:(>=|>|<=|<|!=|==?)\s*)?(.+)\s*$`)
 
-type constraintFunc func(a, b *Version) bool
-type constraint struct {
-	f        constraintFunc
-	b        *Version
-	original string
-}
+type (
+	constraintFunc    func(a, b *Version) bool
+	constraintSegment struct {
+		f constraintFunc
+		b *Version
+	}
+	Constraint struct {
+		segments []constraintSegment
+		original string
+	}
+)
 
-// Constraints is a collection of version constraint rules that can be checked against a version.
-type Constraints []constraint
-
-// NewConstraint parses a string into a Constraints object that can be used to check
-// if a given version satisfies the constraint.
-func NewConstraint(cs string) (Constraints, error) {
+// NewConstraint parses a string and returns a Contraint and an error if the parsing fails.
+func NewConstraint(cs string) (Constraint, error) {
+	c := Constraint{original: cs}
 	parts := strings.Split(cs, ",")
-	newC := make(Constraints, len(parts))
-	for i, p := range parts {
-		parts[i] = strings.TrimSpace(p)
-	}
-	for i, p := range parts {
-		c, err := newConstraint(p)
+	for _, p := range parts {
+		segments, err := parseSegment(p)
 		if err != nil {
-			return Constraints{}, err
+			return c, err
 		}
-		newC[i] = c
+		c.segments = append(c.segments, segments...)
 	}
 
-	return newC, nil
+	return c, nil
 }
 
 // MustConstraint is like NewConstraint but panics if the constraint is invalid.
-func MustConstraint(cs string) Constraints {
+func MustConstraint(cs string) Constraint {
 	c, err := NewConstraint(cs)
 	if err != nil {
 		panic("github.com/k0sproject/version: NewConstraint: " + err.Error())
@@ -48,17 +46,13 @@ func MustConstraint(cs string) Constraints {
 }
 
 // String returns the constraint as a string.
-func (cs Constraints) String() string {
-	s := make([]string, len(cs))
-	for i, c := range cs {
-		s[i] = c.String()
-	}
-	return strings.Join(s, ", ")
+func (cs Constraint) String() string {
+	return cs.original
 }
 
 // Check returns true if the given version satisfies all of the constraints.
-func (cs Constraints) Check(v *Version) bool {
-	for _, c := range cs {
+func (cs Constraint) Check(v *Version) bool {
+	for _, c := range cs.segments {
 		if c.b.Prerelease() == "" && v.Prerelease() != "" {
 			return false
 		}
@@ -72,7 +66,7 @@ func (cs Constraints) Check(v *Version) bool {
 
 // CheckString is like Check but takes a string version. If the version is invalid,
 // it returns false.
-func (cs Constraints) CheckString(v string) bool {
+func (cs Constraint) CheckString(v string) bool {
 	vv, err := NewVersion(v)
 	if err != nil {
 		return false
@@ -80,53 +74,48 @@ func (cs Constraints) CheckString(v string) bool {
 	return cs.Check(vv)
 }
 
-// String returns the original constraint string.
-func (c *constraint) String() string {
-	return c.original
-}
-
-func newConstraint(s string) (constraint, error) {
+func parseSegment(s string) ([]constraintSegment, error) {
 	match := constraintRegex.FindStringSubmatch(s)
 	if len(match) != 3 {
-		return constraint{}, errors.New("invalid constraint: " + s)
+		return nil, errors.New("invalid constraint: " + s)
 	}
 
 	op := match[1]
 	f, err := opfunc(op)
 	if err != nil {
-		return constraint{}, err
+		return nil, err
 	}
 
 	// convert one or two digit constraints to threes digit unless it's an equality operation
 	if op != "" && op != "=" && op != "==" {
-		segments := strings.Split(match[2], ".")
-		if len(segments) < 3 {
-			lastSegment := segments[len(segments)-1]
+		vSegments := strings.Split(match[2], ".")
+		if len(vSegments) < 3 {
+			lastSegment := vSegments[len(vSegments)-1]
 			var pre string
 			if strings.Contains(lastSegment, "-") {
 				parts := strings.Split(lastSegment, "-")
-				segments[len(segments)-1] = parts[0]
+				vSegments[len(vSegments)-1] = parts[0]
 				pre = "-" + parts[1]
 			}
-			switch len(segments) {
+			switch len(vSegments) {
 			case 1:
 				// >= 1 becomes >= 1.0.0
 				// >= 1-rc.1 becomes >= 1.0.0-rc.1
-				return newConstraint(fmt.Sprintf("%s %s.0.0%s", op, segments[0], pre))
+				return parseSegment(fmt.Sprintf("%s %s.0.0%s", op, vSegments[0], pre))
 			case 2:
 				// >= 1.1 becomes >= 1.1.0
 				// >= 1.1-rc.1 becomes >= 1.1.0-rc.1
-				return newConstraint(fmt.Sprintf("%s %s.%s.0%s", op, segments[0], segments[1], pre))
+				return parseSegment(fmt.Sprintf("%s %s.%s.0%s", op, vSegments[0], vSegments[1], pre))
 			}
 		}
 	}
 
 	target, err := NewVersion(match[2])
 	if err != nil {
-		return constraint{}, err
+		return nil, err
 	}
 
-	return constraint{f: f, b: target, original: s}, nil
+	return []constraintSegment{{f: f, b: target}}, nil
 }
 
 func opfunc(s string) (constraintFunc, error) {
@@ -154,4 +143,3 @@ func gte(a, b *Version) bool { return b.GreaterThanOrEqual(a) }
 func lte(a, b *Version) bool { return b.LessThanOrEqual(a) }
 func eq(a, b *Version) bool  { return b.Equal(a) }
 func neq(a, b *Version) bool { return !b.Equal(a) }
-

--- a/version.go
+++ b/version.go
@@ -409,7 +409,7 @@ func (v *Version) IsZero() bool {
 }
 
 // Satisfies returns true if the version satisfies the supplied constraint
-func (v *Version) Satisfies(constraint Constraints) bool {
+func (v *Version) Satisfies(constraint Constraint) bool {
 	return constraint.Check(v)
 }
 


### PR DESCRIPTION
The `NewConstraint` and `MustConstraint` functions returned a `Constraints` which was `[]constraint`.

This PR hides the slice nature of it and returns a `Constraint` like you would expect from `NewConstraint`.
